### PR TITLE
Add basic error handling around wsConnTuple.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .stack-work/*
+*swp

--- a/brbot.cabal
+++ b/brbot.cabal
@@ -1,5 +1,5 @@
 name:                brbot
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            Initial project template from stack
 description:         Please see README.md
 homepage:            http://github.com/githubuser/brbot#readme
@@ -30,6 +30,7 @@ library
                        , split
                        , wuss == 1.*
                        , sqlite-simple
+                       , errors
   default-language:    Haskell2010
 
 executable brbot-exe

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wall #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 


### PR DESCRIPTION
The existing `wsConnTuple` makes some use of `!!` which I avoid.  Death to partial functions!

Here I've introduced some basic error-handling around that by using `Either String`, which just lets me carry around a simple informative string in the bad case.

Often you'd want to introduce a new data type for errors, i.e.

    data Error = InvalidUrl | ...

and then use `Either Error`, with associated `Show` or other pretty-printing instance for the error type.  But for simplicity `Either String` works fine.  The result is that `someFunc` has to deal with the bad case explicitly.

You could also clean this up a bit by using `EitherT String IO (String, String)`.

I also simplified just a couple of cases where you could get away with a single `return`, instead of two.
